### PR TITLE
Update onboarding checklist: Halket building access

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We are committed to creating a diverse team that is inclusive to all cultural an
 
 ### Onboarding checklist
 
-- [ ] Get building access to BST3 and Murdoch by filling out the [CSB Access Request Form](https://forms.office.com/pages/responsepage.aspx?id=ifT5nqDg606HzDpSYRL9DdzwsnPuT99GkKDXIhKUpDlUQ0dRQVRFTDZJRFAxVE4yTUVIWTEwMUpBQy4u). Wait 2-3 days for access. If the form or your card does not work, please contact [Jennifer Watt](jcwatt@pitt.edu).
+- [ ] Get building access to the Fifth and Halket building by filling out the [Fifth and Halket Building Access Request Form](https://forms.cloud.microsoft/pages/responsepage.aspx?id=ifT5nqDg606HzDpSYRL9DSLv1OIJN6pMpZ0LOVlyP3hUREs5T0dPVElSSkFWUkFRVTZUSUpGQlQyVy4u&route=shorturl). Wait 2-3 days for access. If the form or your card does not work, please contact [Jennifer Watt](jcwatt@pitt.edu).
 - [ ] Join departmental mailing list via  [CSB Email List Subscription Form](https://forms.office.com/pages/responsepage.aspx?id=ifT5nqDg606HzDpSYRL9DdzwsnPuT99GkKDXIhKUpDlUQVk2QTRIMUxQM0lHUU5WTFJGWjU4V1k5Uy4u).
 - [ ] Join [CSB Department's sharepoint site](https://pitt.sharepoint.com/sites/ProjectB).
 - [ ] Join Slack groups (Ask Keisuke or others for invite.)


### PR DESCRIPTION
## Summary

- Replaces the old BST3/Murdoch building access instructions with the new Fifth and Halket building access request form
- Uses the form URL confirmed by Jennifer Watt in issue #20

Closes #20